### PR TITLE
Adding a new feed option ignore_codes

### DIFF
--- a/config/Rbl.php
+++ b/config/Rbl.php
@@ -51,20 +51,20 @@ return [
      */
     'feeds' => [
         'Spamhaus' => [
-            'zone'      => 'zen.spamhaus.org',
-            'class'     => 'RBL_LISTED',
-            'type'      => 'ABUSE',
-            'enabled'   => true,
-            'fields'    => [
+            'zone'         => 'zen.spamhaus.org',
+            'class'        => 'RBL_LISTED',
+            'type'         => 'ABUSE',
+            'enabled'      => true,
+            'fields'       => [
                 //
             ],
-            'filters'   => [
+            'filters'      => [
                 //
             ],
-            'information' => [
+            'information'  => [
                 'delisting url' => 'https://www.spamhaus.org/lookup/',
             ],
-            'codes'     => [
+            'codes'        => [
                 '127.0.0.2'     => 'SBL Listing - Contains: Direct UBE sources, spam operations & spam service',
                 '127.0.0.3'     => 'CSS Listing - Contains: Direct snowshoe spam sources detected via automation',
                 '127.0.0.4'     => 'XBL Listing - Contains: CBL (3rd party exploits such as proxies, trojans, etc.)',
@@ -77,29 +77,35 @@ return [
                     'PBL Listing - Contains: End-user Non-MTA IP addresses set by ISP outbound mail policy',
                 'default'       => 'SPAM Sending host'
             ],
-            'method'    => 'dns',
-            'zonefile'  => '',
+            'ignore_codes' => [
+                //
+            ],
+            'method'       => 'dns',
+            'zonefile'     => '',
         ],
         'Spamcop' => [
-            'zone'      => 'bl.spamcop.net',
-            'class'     => 'RBL_LISTED',
-            'type'      => 'ABUSE',
-            'enabled'   => true,
-            'fields'    => [
+            'zone'         => 'bl.spamcop.net',
+            'class'        => 'RBL_LISTED',
+            'type'         => 'ABUSE',
+            'enabled'      => true,
+            'fields'       => [
                 //
             ],
-            'filters'   => [
+            'filters'      => [
                 //
             ],
-            'information' => [
+            'information'  => [
                 'delisting url' => 'https://www.spamcop.net/bl.shtml',
             ],
-            'codes'     => [
+            'codes'        => [
                 '127.0.0.2'     => 'SCBL Listing - Contains: End-user reports, SPAM traps and other detection types',
                 'default'       => 'SPAM Sending host'
             ],
-            'method'    => 'dns',
-            'zonefile'  => '',
+            'ignore_codes' => [
+                //
+            ],
+            'method'       => 'dns',
+            'zonefile'     => '',
         ],
     ],
 ];

--- a/src/Rbl.php
+++ b/src/Rbl.php
@@ -69,6 +69,7 @@ class Rbl extends Collector
         'filters'       => 'sometimes|array',
         'information'   => 'sometimes|array',
         'codes'         => 'required|array',
+        'ignore_codes'  => 'sometimes|array',
         'method'        => 'required|string',
         'zonefile'      => 'sometimes|file',
     ];
@@ -298,6 +299,11 @@ class Rbl extends Collector
 
                     if ($result = gethostbyname($lookup)) {
                         if ($result != $lookup) {
+                            // Stop processing if result on ignore_codes list
+                            if (array_key_exists($result, $feedData['ignore_codes'])) {
+                               continue;
+                            }
+
                             // If config is empty, we fall back to this
                             $reason = 'SPAM Sending host';
 


### PR DESCRIPTION
This allows for ignoring specific RBL return codes, i.e.

```
    'ignore_codes' => [ 
        '127.0.0.10' => '',
        '127.0.0.11' => ''
   ],
```

The idea is that we need an option to exclude PBL from Spamhaus that return 127.0.0.10 and 127.0.0.11.

